### PR TITLE
feat: add file manager handlers for dummy lib

### DIFF
--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -1,4 +1,4 @@
-"""TO-DO: Write a description of what this XBlock is."""
+"""Definition for the Files Manager XBlock."""
 import logging
 
 import pkg_resources
@@ -138,8 +138,6 @@ class FilesManagerXBlock(XBlock):
         """
         The edit view of the FilesManagerXBlock in Studio.
         """
-        if context:
-            pass  # TO-DO: do something based on the context.
         html = self.resource_string("static/html/filesmanager.html")
         frag = Fragment(html.format(self=self))
         frag.add_css(self.resource_string("static/css/filesmanager.css"))
@@ -269,8 +267,16 @@ class FilesManagerXBlock(XBlock):
             from cms.djangoapps.contentstore.asset_storage_handler import update_course_run_asset  # pylint: disable=import-outside-toplevel
         path = request.params.get("path")
         target_directory = self.get_target_directory(path)
-        for type, file in request.params.items():
-            if not type.startswith("file"):
+        if not target_directory:
+            return Response(
+                status=HTTPStatus.NOT_FOUND,
+                json_body={
+                    "status": "error",
+                    "message": "Target directory not found",
+                }
+            )
+        for content_type, file in request.params.items():
+            if not content_type.startswith("file"):
                 continue
             try:
                 content = update_course_run_asset(self.course_id, file.file)

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -342,19 +342,19 @@ class FilesManagerXBlock(XBlock):
 
         Returns: the content of the parent directory.
         """
-        path = data.get("path")
-        if not path:
+        paths = data.get("paths")
+        if not paths:
             return {
                 "status": "error",
                 "message": "Path not found",
             }
-        content, index, parent_directory = self.get_content_by_path(path)
-        if content:
-            del parent_directory[index]
-            self.delete_content_from_assets(content)
+        for path in paths:
+            content, index, parent_directory = self.get_content_by_path(path)
+            if content:
+                del parent_directory[index]
+                self.delete_content_from_assets(content)
         return {
             "status": "success",
-            "content": parent_directory,
         }
 
     def get_target_directory(self, path):

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -232,7 +232,6 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def delete_content(self, data, suffix=''):
-        import pudb; pu.db
         path = data.get("path")
         if not path:
             return {}

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -267,16 +267,17 @@ class FilesManagerXBlock(XBlock):
                 "status": "error",
                 "message": "Content not found",
             }
-        content["path"] = f"{target_content['path']}/{content['name']}"
+        new_content_path = f"{target_content['path']}/{content['name']}"
         del source_parent_directory[index]
         if target_index is None:
             target_content["children"].append(content)
         else:
-            target_index = int(target_index)
+            target_index = 0 if not target_index else int(target_index)
             new_target_content_directory_children = target_content["children"][:target_index]
             new_target_content_directory_children.append(content)
             new_target_content_directory_children.extend(target_content["children"][target_index:])
             target_content["children"] = new_target_content_directory_children
+        self.update_content_path(content, new_content_path)
         return {
             "status": "success",
             "content": target_parent_directory,
@@ -337,6 +338,13 @@ class FilesManagerXBlock(XBlock):
                     parent_directory = content["children"]
                     break
         return None, None, None
+
+    def update_content_path(self, content, path):
+        """Update the path of a content."""
+        content["path"] = path
+        if content.get("type") == "directory":
+            for child in content.get("children", []):
+                self.update_content_path(child, f"{path}/{child['name']}")
 
     def delete_content_from_assets(self, content):
         """Delete a content from the course assets."""

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -236,7 +236,7 @@ class FilesManagerXBlock(XBlock):
         directory_name = data.get("name")
         path = data.get("path")
         target_directory = self.get_target_directory(path)
-        if not target_directory:
+        if target_directory is None:
             return {
                 "status": "error",
                 "message": "Target directory not found",

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -101,12 +101,6 @@ class FilesManagerXBlock(XBlock):
         help="List of directories to be displayed in the Files Manager."
     )
 
-    incremental_directory_id = Integer(
-        default=0,
-        scope=Scope.settings,
-        help="Incremental ID for directories."
-    )
-
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""
         data = pkg_resources.resource_string(__name__, path)
@@ -195,7 +189,6 @@ class FilesManagerXBlock(XBlock):
         Returns: an empty list of directories.
         """
         self.directories = []
-        self.incremental_directory_id = 0
         return {
             "status": "success",
             "content": self.directories,
@@ -250,13 +243,10 @@ class FilesManagerXBlock(XBlock):
                 "name": directory_name,
                 "type": "directory",
                 "path": f"{path}/{directory_name}" if path else directory_name,
-                "metadata": {
-                    "id": self.incremental_directory_id,
-                },
+                "metadata": {},  # Empty for now but could be used to store the directory data needed by Chonky.
                 "children": [],
             }
         )
-        self.incremental_directory_id += 1
         return {
             "status": "success",
             "content": target_directory,

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -33,12 +33,19 @@ log = logging.getLogger(__name__)
 
 class FilesManagerXBlock(XBlock):
     """
+    Xblock to manage files which live in the course assets.
+
+
+    This xblock is intended to be used as a presentation layer for the course assets.
+    It allows to add, delete and reorganize files and (virtual) directories in the course assets.
+    It also allows to upload files to the course assets.
+
     Example of directories list:
     [
         {
             "name": "Folder 1",
-            "type": "folder",
-            "path": "folder1",
+            "type": "directory",
+            "path": "Folder 1",
             "metadata": {
                 "id": ..,
                 ...
@@ -47,7 +54,7 @@ class FilesManagerXBlock(XBlock):
                 {
                     "name": "File 1",
                     "type": "file",
-                    "path": "folder1/file1"
+                    "path": "Folder 1/File 1"
                     "metadata": {
                         "id": ..,
                         "asset_key": ..,
@@ -60,8 +67,8 @@ class FilesManagerXBlock(XBlock):
                     },
                 {
                     "name": "Folder 2",
-                    "type": "folder",
-                    "path": "folder1/folder2",
+                    "type": "directory",
+                    "path": "Folder 1/Folder 2",
                     "metadata": {
                         "id": ..,
                         ...
@@ -70,7 +77,7 @@ class FilesManagerXBlock(XBlock):
                         {
                             "name": "File 2",
                             "type": "file",
-                            "path": "folder1/folder2/file2"
+                            "path": "Folder 1/Folder 2/File 2"
                             "metadata": {
                                 "id": ..,
                                 "asset_key": ..,
@@ -154,6 +161,7 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def get_directories(self, data, suffix=''):
+        """Return the list of directories."""
         return {
             "status": "success",
             "content": self.directories,
@@ -161,6 +169,7 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def clear_directories(self, data, suffix=''):
+        """Clear the list of directories without removing files from course assets."""
         self.directories = []
         self.incremental_directory_id = 0
         return {
@@ -170,6 +179,7 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def get_content(self, data, suffix=''):
+        """Return the content of a directory."""
         path = data.get("path")
         if not path:
             return {
@@ -184,6 +194,7 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def add_directory(self, data, suffix=''):
+        """Add a directory to a target directory."""
         directory_name = data.get("name")
         path = data.get("path")
         target_directory = self.get_target_directory(path)
@@ -243,6 +254,7 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def reorganize_content(self, data, suffix=''):
+        """Reorganize a content from a source path to a target path."""
         target_path = data.get("target_path")
         source_path = data.get("source_path")
         target_index = data.get("target_index")
@@ -272,6 +284,7 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def delete_content(self, data, suffix=''):
+        """Delete a content from the course assets."""
         path = data.get("path")
         if not path:
             return {
@@ -288,6 +301,7 @@ class FilesManagerXBlock(XBlock):
         }
 
     def get_target_directory(self, path):
+        """Return the target directory for a given path."""
         target_directory = self.directories
         if path:
             target_directory, _, _ = self.get_content_by_path(path)
@@ -312,6 +326,7 @@ class FilesManagerXBlock(XBlock):
         }
 
     def get_content_by_path(self, path):
+        """Return the (content, index, parent directory) for a given content path."""
         path_tree = path.split("/")
         parent_directory = self.directories
         for directory in path_tree:
@@ -324,6 +339,7 @@ class FilesManagerXBlock(XBlock):
         return None, None, None
 
     def delete_content_from_assets(self, content):
+        """Delete a content from the course assets."""
         if content.get("type") == "file":
             if asset_key := content.get("metadata", {}).get("asset_key"):
                 self.delete_asset(asset_key)
@@ -336,6 +352,7 @@ class FilesManagerXBlock(XBlock):
                 self.delete_content_from_assets(child)
 
     def delete_asset(self, asset_key):
+        """Delete an asset from the course assets."""
         try:
             from cms.djangoapps.contentstore.views.assets import delete_asset  # pylint: disable=import-outside-toplevel
         except ImportError:

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -375,7 +375,7 @@ class FilesManagerXBlock(XBlock):
         """Delete a content from the course assets.
 
         Arguments:
-            path: the path of the content to be deleted.
+            paths: list of paths of the content to be deleted.
 
         Returns: the content of the parent directory.
         """

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -259,7 +259,10 @@ class FilesManagerXBlock(XBlock):
         source_path = data.get("source_path")
         target_index = data.get("target_index")
         if not target_path or not source_path:
-            return {}
+            return {
+                "status": "error",
+                "message": "Path not found",
+            }
         content, index, source_parent_directory = self.get_content_by_path(source_path)
         target_content, _, target_parent_directory = self.get_content_by_path(target_path)
         if not content or not target_content:

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -155,6 +155,7 @@ class FilesManagerXBlock(XBlock):
     @XBlock.json_handler
     def get_directories(self, data, suffix=''):
         return {
+            "status": "success",
             "content": self.directories,
         }
 
@@ -163,6 +164,7 @@ class FilesManagerXBlock(XBlock):
         self.directories = []
         self.incremental_directory_id = 0
         return {
+            "status": "success",
             "content": self.directories,
         }
 
@@ -170,7 +172,10 @@ class FilesManagerXBlock(XBlock):
     def get_content(self, data, suffix=''):
         path = data.get("path")
         if not path:
-            return {}
+            return {
+                "status": "error",
+                "message": "Path not found",
+            }
         content, _, _ = self.get_content_by_path(path)
         return {
             "status": "success",
@@ -182,6 +187,11 @@ class FilesManagerXBlock(XBlock):
         directory_name = data.get("name")
         path = data.get("path")
         target_directory = self.get_target_directory(path)
+        if not target_directory:
+            return {
+                "status": "error",
+                "message": "Target directory not found",
+            }
         target_directory.append(
             {
                 "name": directory_name,
@@ -195,6 +205,7 @@ class FilesManagerXBlock(XBlock):
         )
         self.incremental_directory_id += 1
         return {
+            "status": "success",
             "content": target_directory,
         }
 

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -9,12 +9,17 @@ from xblock.fields import Integer, Scope, List
 from xblock.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 
+from http import HTTPStatus
 from urllib.parse import urljoin
 
+import pkg_resources
 from django.conf import settings
-
-from http import HTTPStatus
+from django.utils import translation
 from webob.response import Response
+from xblock.core import XBlock
+from xblock.fields import Integer, List, Scope
+from xblock.fragment import Fragment
+from xblockutils.resources import ResourceLoader
 
 try:
     from cms.djangoapps.contentstore.exceptions import AssetNotFoundException
@@ -262,9 +267,11 @@ class FilesManagerXBlock(XBlock):
         """
         # Temporary fix for supporting both contentstore assets management versions (master / Palm)
         try:
-            from cms.djangoapps.contentstore.views.assets import update_course_run_asset  # pylint: disable=import-outside-toplevel
+            from cms.djangoapps.contentstore.views.assets import \
+                update_course_run_asset  # pylint: disable=import-outside-toplevel
         except ImportError:
-            from cms.djangoapps.contentstore.asset_storage_handler import update_course_run_asset  # pylint: disable=import-outside-toplevel
+            from cms.djangoapps.contentstore.asset_storage_handler import \
+                update_course_run_asset  # pylint: disable=import-outside-toplevel
         path = request.params.get("path")
         target_directory = self.get_target_directory(path)
         if not target_directory:
@@ -463,7 +470,8 @@ class FilesManagerXBlock(XBlock):
         try:
             from cms.djangoapps.contentstore.views.assets import delete_asset  # pylint: disable=import-outside-toplevel
         except ImportError:
-            from cms.djangoapps.contentstore.asset_storage_handler import delete_asset  # pylint: disable=import-outside-toplevel
+            from cms.djangoapps.contentstore.asset_storage_handler import \
+                delete_asset  # pylint: disable=import-outside-toplevel
         asset_key = AssetKey.from_string(asset_key)
         try:
             delete_asset(self.course_id, asset_key)

--- a/filesmanager/static/html/filesmanager.html
+++ b/filesmanager/static/html/filesmanager.html
@@ -19,6 +19,15 @@
     <button id="delete-content" type="submit"> Delete content </button>
 </div>
 <div>
+    <input id="content-reorganize-source-path" name="content-path"/>
+    <label for="content-reorganize-source-path"> Source path </label>
+    <input id="content-reorganize-target-path" name="content-path"/>
+    <label for="content-reorganize-target-path"> Target path </label>
+    <input id="content-reorganize-index" name="content"/>
+    <label for="content-reorganize-index"> Index </label>
+    <button id="reorganize-content" type="submit"> Reorganize content </button>
+</div>
+<div>
     <form id="file-upload" enctype="multipart/form-data">
         <input id="path" name="path"/>
         <label for="content-file-path"> Path </label>

--- a/filesmanager/static/html/filesmanager.html
+++ b/filesmanager/static/html/filesmanager.html
@@ -14,10 +14,6 @@
     <button id="get-asset-by-path" type="submit"> Get content by path </button>
 </div>
 <div>
-    <input id="content-delete-id" name="content-id"/>
-    <label for="content-delete-id"> ID </label>
-    <input id="content-delete-type" name="content-type"/>
-    <label for="content-delete-type"> Type </label>
     <input id="content-delete-path" name="content-path"/>
     <label for="content-delete-path"> Path </label>
     <button id="delete-content" type="submit"> Delete content </button>

--- a/filesmanager/static/html/filesmanager.html
+++ b/filesmanager/static/html/filesmanager.html
@@ -9,17 +9,33 @@
     <button id="add-directory" type="submit"> Add directory </button>
 </div>
 <div>
-    <input id="content-id" name="content-id"/>
-    <label for="content-id"> ID </label>
-    <input id="content-type" name="content-type"/>
-    <label for="content-type"> Type </label>
     <input id="content-path" name="content-path"/>
     <label for="content-path"> Path </label>
-    <button id="get-asset-by-id" type="submit"> Get content by ID </button>
+    <button id="get-asset-by-path" type="submit"> Get content by path </button>
+</div>
+<div>
+    <input id="content-delete-id" name="content-id"/>
+    <label for="content-delete-id"> ID </label>
+    <input id="content-delete-type" name="content-type"/>
+    <label for="content-delete-type"> Type </label>
+    <input id="content-delete-path" name="content-path"/>
+    <label for="content-delete-path"> Path </label>
+    <button id="delete-content" type="submit"> Delete content </button>
+</div>
+<div>
+    <form id="file-upload" enctype="multipart/form-data">
+        <input id="path" name="path"/>
+        <label for="content-file-path"> Path </label>
+        <input type="file" id="files" name="files" multiple/>
+        <button value="Upload" type="submit" >Upload files</button>
+    </form>
 </div>
 <div>
     <button id="get-directories" type="submit"> Get directories </button>
 </div>
+<!-- <div>
+    <button id="clear-directories" type="submit"> Clear directories </button>
+</div> -->
 
 <!-- <div style="display: block;">
     <button id="get-folder-by-name" type="submit"> GET FOLDER BY NAME </button>

--- a/filesmanager/static/html/filesmanager.html
+++ b/filesmanager/static/html/filesmanager.html
@@ -1,3 +1,36 @@
 <div class="filesmanager_block">
-    <p>FilesManagerXBlock: count is now <span class="count">{self.count}</span> (click me to increment).</p>
+<p>FilesManagerXBlock</p>
+
+<div>
+    <input id="directory-name" name="directory-name"/>
+    <label for="directory-name"> Directory name </label>
+    <input id="directory-path" path="directory-path"/>
+    <label for="directory-path"> Directory path </label>
+    <button id="add-directory" type="submit"> Add directory </button>
+</div>
+<div>
+    <input id="content-id" name="content-id"/>
+    <label for="content-id"> ID </label>
+    <input id="content-type" name="content-type"/>
+    <label for="content-type"> Type </label>
+    <input id="content-path" name="content-path"/>
+    <label for="content-path"> Path </label>
+    <button id="get-asset-by-id" type="submit"> Get content by ID </button>
+</div>
+<div>
+    <button id="get-directories" type="submit"> Get directories </button>
+</div>
+
+<!-- <div style="display: block;">
+    <button id="get-folder-by-name" type="submit"> GET FOLDER BY NAME </button>
+</div>
+<div style="display: block;">
+    <button id="upload-asset-to-folder" type="submit"> UPLOAD ASSET TO FOLDER </button>
+</div>
+<div style="display: block;">
+    <button id="remove-asset-from-folder" type="submit"> REMOVE ASSET FROM FOLDER </button>
+</div>
+<div style="display: block;">
+    <button id="move-asset" type="submit"> MOVE ASSET </button>
+</div> -->
 </div>

--- a/filesmanager/static/js/src/filesmanager.js
+++ b/filesmanager/static/js/src/filesmanager.js
@@ -1,28 +1,53 @@
 /* Javascript for FilesManagerXBlock. */
 function FilesManagerXBlock(runtime, element) {
 
-    function updateCount(result) {
-        $('.count', element).text(result.count);
-    }
+    var getDirectories = runtime.handlerUrl(element, 'get_directories');
+    var getAssetHandler = runtime.handlerUrl(element, 'get_content');
+    var addDirectoryHandler = runtime.handlerUrl(element, 'add_directory');
 
-    var handlerUrl = runtime.handlerUrl(element, 'increment_count');
 
-    $('p', element).click(function(eventObject) {
-        $.ajax({
-            type: "POST",
-            url: handlerUrl,
-            data: JSON.stringify({"hello": "world"}),
-            success: updateCount
+    $(element).find(`#get-directories`).click(function () {
+        const data = {}
+        $.post(getDirectories, JSON.stringify(data))
+        .done(function (response) {
+            console.log(response);
+        })
+        .fail(function () {
+            console.log("Error getting assets");
         });
     });
 
-    $(function ($) {
-        /*
-        Use `gettext` provided by django-statici18n for static translations
+    $(element).find(`#get-asset-by-id`).click(function () {
+        const id = $(element).find("#content-id").val();
+        const type = $(element).find("#content-type").val();
+        const path = $(element).find("#content-path").val();
+        const data = {
+            "content_id": id,
+            "type": type,
+            "path": path,
+        }
+        $.post(getAssetHandler, JSON.stringify(data))
+        .done(function (response) {
+            console.log(response);
+        })
+        .fail(function () {
+            console.log("Error getting assets");
+        });
+    });
 
-        var gettext = FilesManagerXBlocki18n.gettext;
-        */
-
-        /* Here's where you'd do things on page load. */
+    $(element).find(`#add-directory`).click(function () {
+        const directoryName = $(element).find("#directory-name").val();
+        const directoryPath = $(element).find("#directory-path").val();
+        const data = {
+            "name": directoryName,
+            "path": directoryPath,
+        }
+        $.post(addDirectoryHandler, JSON.stringify(data))
+        .done(function (response) {
+            console.log(response);
+        })
+        .fail(function () {
+            console.log("Error adding directory");
+        });
     });
 }

--- a/filesmanager/static/js/src/filesmanager.js
+++ b/filesmanager/static/js/src/filesmanager.js
@@ -7,6 +7,7 @@ function FilesManagerXBlock(runtime, element) {
     var deleteContentHandler = runtime.handlerUrl(element, 'delete_content');
     var addDirectoryHandler = runtime.handlerUrl(element, 'add_directory');
     var uploadFilesHandler = runtime.handlerUrl(element, 'upload_files');
+    var reorganizeContentHandler = runtime.handlerUrl(element, 'reorganize_content');
 
 
     $(element).find(`#get-directories`).click(function () {
@@ -78,6 +79,25 @@ function FilesManagerXBlock(runtime, element) {
             console.log("Error getting assets");
         });
     });
+
+    $(element).find(`#reorganize-content`).click(function () {
+        const source_path = $(element).find("#content-reorganize-source-path").val();
+        const target_path = $(element).find("#content-reorganize-target-path").val();
+        const new_index = $(element).find("#content-reorganize-index").val();
+        const data = {
+            "source_path": source_path,
+            "target_path": target_path,
+            "target_index": new_index,
+        }
+        $.post(reorganizeContentHandler, JSON.stringify(data))
+        .done(function (response) {
+            console.log(response);
+        })
+        .fail(function () {
+            console.log("Error getting assets");
+        });
+    });
+
 
     $(element).find(`#add-directory`).click(function () {
         const directoryName = $(element).find("#directory-name").val();

--- a/filesmanager/static/js/src/filesmanager.js
+++ b/filesmanager/static/js/src/filesmanager.js
@@ -2,8 +2,11 @@
 function FilesManagerXBlock(runtime, element) {
 
     var getDirectories = runtime.handlerUrl(element, 'get_directories');
+    var clearDirectories = runtime.handlerUrl(element, 'clear_directories');
     var getAssetHandler = runtime.handlerUrl(element, 'get_content');
+    var deleteContentHandler = runtime.handlerUrl(element, 'delete_content');
     var addDirectoryHandler = runtime.handlerUrl(element, 'add_directory');
+    var uploadFilesHandler = runtime.handlerUrl(element, 'upload_files');
 
 
     $(element).find(`#get-directories`).click(function () {
@@ -17,16 +20,61 @@ function FilesManagerXBlock(runtime, element) {
         });
     });
 
-    $(element).find(`#get-asset-by-id`).click(function () {
-        const id = $(element).find("#content-id").val();
-        const type = $(element).find("#content-type").val();
+    $(element).find(`#clear-directories`).click(function () {
+        const data = {}
+        $.post(clearDirectories, JSON.stringify(data))
+        .done(function (response) {
+            console.log(response);
+        })
+        .fail(function () {
+            console.log("Error getting assets");
+        });
+    });
+
+    $(element).find(`#file-upload`).submit(function (e) {
+        e.preventDefault();
+        const formData = new FormData(this);
+        $.post(
+            {
+                url: uploadFilesHandler,
+                data: formData,
+                processData: false,
+                contentType: false,
+                type: 'POST',
+            }
+        )
+        .done(function (response) {
+            console.log(response);
+        })
+        .fail(function () {
+            console.log("Error getting assets");
+        });
+    });
+
+    $(element).find(`#get-asset-by-path`).click(function () {
         const path = $(element).find("#content-path").val();
+        const data = {
+            "path": path,
+        }
+        $.post(getAssetHandler, JSON.stringify(data))
+        .done(function (response) {
+            console.log(response);
+        })
+        .fail(function () {
+            console.log("Error getting assets");
+        });
+    });
+
+    $(element).find(`#delete-content`).click(function () {
+        const id = $(element).find("#content-delete-id").val();
+        const type = $(element).find("#content-delete-type").val();
+        const path = $(element).find("#content-delete-path").val();
         const data = {
             "content_id": id,
             "type": type,
             "path": path,
         }
-        $.post(getAssetHandler, JSON.stringify(data))
+        $.post(deleteContentHandler, JSON.stringify(data))
         .done(function (response) {
             console.log(response);
         })

--- a/filesmanager/static/js/src/filesmanager.js
+++ b/filesmanager/static/js/src/filesmanager.js
@@ -66,12 +66,8 @@ function FilesManagerXBlock(runtime, element) {
     });
 
     $(element).find(`#delete-content`).click(function () {
-        const id = $(element).find("#content-delete-id").val();
-        const type = $(element).find("#content-delete-type").val();
         const path = $(element).find("#content-delete-path").val();
         const data = {
-            "content_id": id,
-            "type": type,
             "path": path,
         }
         $.post(deleteContentHandler, JSON.stringify(data))

--- a/filesmanager/static/js/src/filesmanager.js
+++ b/filesmanager/static/js/src/filesmanager.js
@@ -67,9 +67,9 @@ function FilesManagerXBlock(runtime, element) {
     });
 
     $(element).find(`#delete-content`).click(function () {
-        const path = $(element).find("#content-delete-path").val();
+        const paths = $(element).find("#content-delete-path").val();
         const data = {
-            "path": path,
+            "paths": paths.split(",").map(path => path.trim()),
         }
         $.post(deleteContentHandler, JSON.stringify(data))
         .done(function (response) {


### PR DESCRIPTION
### Description

This PR adds the minimum handlers to manage (add, remove, move...) content using the Xblock interface.

Glossary:
- Directory: a dictionary with references to content (other directories or files)
- Content refers to content when an object can be a directory or file.
- Asset: course assets.

### How to test
We created an application in the Studio edit view to test these handlers, which is a temporary solution. The next step for this implementation is to be integrated with the Chunky library. To test this PR out:

1. Add this xblock to your course
2. Create a new component with this Xblock
3. Edit > Use the xblock dummy interface

Now, test each of the handlers specified below.

#### Get directories
**Description:** returns all directories created with the xblock following this folder structure
**Handler name:** `get_directory`
**Arguments:** N/A
```
    [
        {
            "name": "Folder 1",
            "type": "directory",
            "path": "Folder 1",
            "metadata": {
                "id": ..,
                ...
            },
            "children": [
                {
                    "name": "File 1",
                    "type": "file",
                    "path": "Folder 1/File 1"
                    "metadata": {
                        "id": ..,
                        "asset_key": ..,
                        "display_name": ..,
                        "url": ..,
                        "content_type": ..,
                        "file_size": ..,
                        "external_url": ..,
                        "thumbnail": ..,
                    },
                {
                    "name": "Folder 2",
                    "type": "directory",
                    "path": "Folder 1/Folder 2",
                    "metadata": {
                        "id": ..,
                        ...
                    },
                    "children": [
                        {
                            "name": "File 2",
                            "type": "file",
                            "path": "Folder 1/Folder 2/File 2"
                            "metadata": {
                                "id": ..,
                                "asset_key": ..,
                                "display_name": ..,
                                "url": ..,
                                "content_type": ..,
                                "file_size": ..,
                                "external_url": ..,
                                "thumbnail": ..,
                            },
                        }
                    ]
                }
            ]
    ]
```
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/458bbcf2-e01c-4cda-948e-ab381e4cea22)

#### Add directory
**Description:** creates directory and returns parent directory content. If the parent directory doesn't exist, it returns an error.
**Handler name:** `add_directory`
**Arguments:** 
- Name (`name`): unique name of the directory. This will also be used at the end of the directory path.
- Path (`path`): target path where the directory will be created. The path is used to identify content. The final path of a new directory would be: `<TARGET PATH>/<DIRECTORY NAME>`

![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/3a40f37b-a42b-4457-9354-a99317ee8d8b)

#### Get content by path
**Description:** returns content (directory/file) specified by the path. If it doesn't exist, it returns empty dict.
**Handler name:** `get_content`
**Arguments:**
- Path (`path`): path of the content to be returned. Since content names are unique strings, then all paths are considered unique.

![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/2c5aaaf7-c9cd-4bbe-a7ea-c9bab5160fee)

#### Delete content
**Description:** given the unique content path, remove the content and return the updated parent directory (children).
**Handler name:** `delete_content`
**Arguments:**
- Paths (`paths`): list of paths of the content to be deleted separated by a comma. Since content names are unique strings, then all paths are considered unique. If the content is of type `file`, it is considered an asset and removed from the course assets.

![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/e152aeb9-d8d5-4f68-aebc-fbf0b7d57b31)
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/4d989a04-f99d-4b37-bce5-3a3416e70fd2)

#### Upload files
**Description:** upload files in the specified directory path, returns the updated parent directory content (children).
**Handler name:** `upload_files`
**Arguments:**
- FormData with files to be uploaded.
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/6670c429-e7ad-4d1c-9837-36d7e0db6ad2)

#### Reorganize content
**Description:** moves content from a source to a target. When the source path is a directory, all paths are updated with the target path.
**Handler name:** `reorganize_content`
**Arguments:**
- Source path: where to look for the content to move.
- Target path: where to put the content.
- Target index: in what position to put the content.
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/55aedcfb-3698-43c8-973d-c272857f1072)
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/f4225dab-67d5-401e-863f-4b095b37d6eb)
