### PR TITLE
feat: add an unpublished directory for unorganized course assets

### DIFF
--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -208,6 +208,7 @@ class FilesManagerXBlock(XBlock):
         self.directories = []
         self.incremental_directory_id = 0
         return {
+            "status": "success",
             "content": self.directories,
         }
 

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -35,6 +35,7 @@ except ImportError:
     AssetKey = None
 
 log = logging.getLogger(__name__)
+COURSE_ASSETS_PAGE_SIZE = 100
 
 class FilesManagerXBlock(XBlock):
     """
@@ -481,18 +482,15 @@ class FilesManagerXBlock(XBlock):
         Returns: the serialized assets.
         """
         current_page = 0
-        page_size = 100
-        sort = None
-        filter_params = None
-        start = current_page * page_size
+        start = current_page * COURSE_ASSETS_PAGE_SIZE
         serialized_course_assets = []
         while True:
             course_assets_for_page, _ = contentstore().get_all_content_for_course(
                 self.course_id,
-                start=current_page * page_size,
-                maxresults=page_size,
-                sort=sort,
-                filter_params=filter_params,
+                start=current_page * COURSE_ASSETS_PAGE_SIZE,
+                maxresults=COURSE_ASSETS_PAGE_SIZE,
+                sort=None,
+                filter_params={},
             )
             if not course_assets_for_page:
                 break
@@ -501,7 +499,7 @@ class FilesManagerXBlock(XBlock):
                     serialized_course_assets.append(self.get_asset_json_from_dict(content))
                     continue
                 serialized_course_assets.append(self.get_asset_json_from_content(content))
-            start += page_size
+            start += COURSE_ASSETS_PAGE_SIZE
             current_page += 1
         return serialized_course_assets
 

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -205,6 +205,7 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def clear_directories(self, data, suffix=''):
+        """Clear the list of directories without removing files from course assets."""
         self.directories = []
         self.incremental_directory_id = 0
         return {

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -205,7 +205,12 @@ class FilesManagerXBlock(XBlock):
 
     @XBlock.json_handler
     def clear_directories(self, data, suffix=''):
-        """Clear the list of directories without removing files from course assets."""
+        """Clear the list of directories without removing files from course assets.
+
+        This method is intended to be used for testing purposes.
+
+        Returns: an empty list of directories.
+        """
         self.directories = []
         self.incremental_directory_id = 0
         return {

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -204,6 +204,14 @@ class FilesManagerXBlock(XBlock):
         }
 
     @XBlock.json_handler
+    def clear_directories(self, data, suffix=''):
+        self.directories = []
+        self.incremental_directory_id = 0
+        return {
+            "content": self.directories,
+        }
+
+    @XBlock.json_handler
     def get_content(self, data, suffix=''):
         """Get the content of a directory.
 

--- a/filesmanager/static/html/filesmanager.html
+++ b/filesmanager/static/html/filesmanager.html
@@ -38,9 +38,12 @@
 <div>
     <button id="get-directories" type="submit"> Get directories </button>
 </div>
-<!-- <div>
+<div>
     <button id="clear-directories" type="submit"> Clear directories </button>
-</div> -->
+</div>
+<div>
+    <button id="fill-directories" type="submit"> Fill directories </button>
+</div>
 
 <!-- <div style="display: block;">
     <button id="get-folder-by-name" type="submit"> GET FOLDER BY NAME </button>

--- a/filesmanager/static/js/src/filesmanager.js
+++ b/filesmanager/static/js/src/filesmanager.js
@@ -3,6 +3,7 @@ function FilesManagerXBlock(runtime, element) {
 
     var getDirectories = runtime.handlerUrl(element, 'get_directories');
     var clearDirectories = runtime.handlerUrl(element, 'clear_directories');
+    var fillDirectories = runtime.handlerUrl(element, 'fill_directories');
     var getAssetHandler = runtime.handlerUrl(element, 'get_content');
     var deleteContentHandler = runtime.handlerUrl(element, 'delete_content');
     var addDirectoryHandler = runtime.handlerUrl(element, 'add_directory');
@@ -31,6 +32,18 @@ function FilesManagerXBlock(runtime, element) {
             console.log("Error getting assets");
         });
     });
+
+    $(element).find(`#fill-directories`).click(function () {
+        const data = {}
+        $.post(fillDirectories, JSON.stringify(data))
+        .done(function (response) {
+            console.log(response);
+        })
+        .fail(function () {
+            console.log("Error getting assets");
+        });
+    });
+
 
     $(element).find(`#file-upload`).submit(function (e) {
         e.preventDefault();

--- a/filesmanager/static/js/src/filesmanager.js
+++ b/filesmanager/static/js/src/filesmanager.js
@@ -57,7 +57,7 @@ function FilesManagerXBlock(runtime, element) {
         const data = {
             "path": path,
         }
-        $.post(getAssetHandler, JSON.stringify(data))
+        $.post(deleteContentHandler, JSON.stringify(data))
         .done(function (response) {
             console.log(response);
         })

--- a/filesmanager/static/js/src/filesmanager.js
+++ b/filesmanager/static/js/src/filesmanager.js
@@ -70,7 +70,7 @@ function FilesManagerXBlock(runtime, element) {
         const data = {
             "path": path,
         }
-        $.post(deleteContentHandler, JSON.stringify(data))
+        $.post(getAssetHandler, JSON.stringify(data))
         .done(function (response) {
             console.log(response);
         })


### PR DESCRIPTION
### Description
This PR adds a default directory called `unpublished` to reference assets that haven't been organized inside a directory using the Xblock UI.

This requirement was required by the PM in charge of this new feature.

### How to test
Start testing the Xblock as usual, setting up your environment. 
1. Now, go to `Files & Uploads` and upload a couple of files
2. Then, go to `Studio > Component view > Edit component`. Now, get the current directories. The files you uploaded previously should appear under the `unpublished` directory after calling `Fill directories`
3. Now, create a new directory and move one of the files to that directory using `Reorganize content`.
4. Now, get the directories. You should see your file under the new directory and not in the uncategorized section.
5. There's also a fill directory handler that when called reads from the course assets and adds the unorganized assets to the uncategorized directory. Try it too by adding content to the course assets without exiting the edit view, and then hit `Fill directories` 