### PR TITLE
refactor!: change folder structure to accommodate Chonky integration

### DIFF
--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -107,13 +107,14 @@ class FilesManagerXBlock(XBlock):
             "parentId": "",
             "metadata": {},
             "children": [
-                {
-                    "name": "Unpublished",
-                    "type": "directory",
-                    "path": "Root/Unpublished",
-                    "metadata": {},
-                    "children": [],
-                }
+                # Commented in the meantime while we figure out how to integrate this folder into Chonky
+                # {
+                #     "name": "Unpublished",
+                #     "type": "directory",
+                #     "path": "Root/Unpublished",
+                #     "metadata": {},
+                #     "children": [],
+                # }
             ],
         },
         scope=Scope.settings,
@@ -325,13 +326,14 @@ class FilesManagerXBlock(XBlock):
             "parentId": "",
             "metadata": {},
             "children": [
-                {
-                    "name": "Unpublished",
-                    "type": "directory",
-                    "path": "Root/Unpublished",
-                    "metadata": {},
-                    "children": [],
-                }
+                # Commented in the meantime while we figure out how to integrate this folder into Chonky
+                # {
+                #     "name": "Unpublished",
+                #     "type": "directory",
+                #     "path": "Root/Unpublished",
+                #     "metadata": {},
+                #     "children": [],
+                # }
             ],
         }
         self.prefill_directories()
@@ -651,7 +653,7 @@ class FilesManagerXBlock(XBlock):
                     {
                         "name": course_asset["display_name"],
                         "type": "file",
-                        "path": f"unpublished/{course_asset['display_name']}",
+                        "path": f"Unpublished/{course_asset['display_name']}",
                         "metadata": course_asset,
                     }
                 )

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -324,7 +324,7 @@ class FilesManagerXBlock(XBlock):
         }
 
     @XBlock.json_handler
-    def add_directory(self, data, suffix=''):
+    def add_directories(self, data, suffix=''):
         """Add a directory to a target directory.
 
         The new directory will:
@@ -338,30 +338,37 @@ class FilesManagerXBlock(XBlock):
             name: the name and path of the directory to be added.
             path: the path of the target directory where the new directory will be added.
         """
-        directory_name = data.get("name")
-        path = data.get("path")
-        target_directory = self.get_target_directory(path)
-        if target_directory is None:
+        directories = data.get("directories")
+        if not directories:
             return {
                 "status": "error",
-                "message": "Target directory not found",
+                "message": "Directories not found in the request",
             }
-        directory_path = f"{path}/{directory_name}" if path else directory_name
-        if directory_path in self.content_ids:
-            return {
-                "status": "error",
-                "message": "Directory already exists",
-            }
-        self.content_ids.append(directory_path)
-        target_directory.append(
-            {
-                "name": directory_name,
-                "type": "directory",
-                "path": f"{path}/{directory_name}" if path else directory_name,
-                "metadata": {},  # Empty for now but could be used to store the directory data needed by Chonky.
-                "children": [],
-            }
-        )
+        for directory in directories:
+            directory_name = directory.get("name")
+            path = directory.get("path")
+            target_directory = self.get_target_directory(path)
+            if target_directory is None:
+                return {
+                    "status": "error",
+                    "message": "Target directory not found",
+                }
+            directory_path = f"{path}/{directory_name}" if path else directory_name
+            if directory_path in self.content_ids:
+                return {
+                    "status": "error",
+                    "message": f"Directory {directory_name} already exists",
+                }
+            self.content_ids.append(directory_path)
+            target_directory.append(
+                {
+                    "name": directory_name,
+                    "type": "directory",
+                    "path": directory_path,
+                    "metadata": {},  # Empty for now but could be used to store the directory data needed by Chonky.
+                    "children": [],
+                }
+            )
         return {
             "status": "success",
             "content": target_directory,

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.utils import translation
 from webob.response import Response
 from xblock.core import XBlock
-from xblock.fields import Dict, List, Scope
+from xblock.fields import Dict, List, Scope, String
 from xblock.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 
@@ -97,16 +97,25 @@ class FilesManagerXBlock(XBlock):
     ]
     """
 
-    directories = List(
-        default=[
-            {
-                "name": "unpublished",
-                "type": "directory",
-                "path": "unpublished",
-                "metadata": {},
-                "children": [],
-            }
-        ],
+    directories = Dict(
+        default=
+        {
+            "id": None,
+            "name": "Root",
+            "type": "directory",
+            "path": "Root",
+            "parentId": "",
+            "metadata": {},
+            "children": [
+                {
+                    "name": "Unpublished",
+                    "type": "directory",
+                    "path": "Root/Unpublished",
+                    "metadata": {},
+                    "children": [],
+                }
+            ],
+        },
         scope=Scope.settings,
         help="List of directories to be displayed in the Files Manager."
     )
@@ -115,6 +124,12 @@ class FilesManagerXBlock(XBlock):
         default=[],
         scope=Scope.settings,
         help="List of content paths to be displayed in the Files Manager."
+    )
+
+    content_ids = List(
+        default=[],
+        scope=Scope.settings,
+        help="List of content (from Chunky) ids to be displayed in the Files Manager."
     )
 
     temporary_uploaded_files = Dict(
@@ -302,9 +317,26 @@ class FilesManagerXBlock(XBlock):
 
         Returns: an empty list of directories.
         """
-        self.initialize_unpublished_directory(remove_all=True)
+        self.directories = {
+            "id": self.directories["id"],
+            "name": "Root",
+            "type": "directory",
+            "path": "Root",
+            "parentId": "",
+            "metadata": {},
+            "children": [
+                {
+                    "name": "Unpublished",
+                    "type": "directory",
+                    "path": "Root/Unpublished",
+                    "metadata": {},
+                    "children": [],
+                }
+            ],
+        }
         self.prefill_directories()
         self.content_paths = []
+        self.content_ids = []
         return {
             "status": "success",
             "content": self.directories,
@@ -366,14 +398,15 @@ class FilesManagerXBlock(XBlock):
             contents = json.loads(request.params.get("contents", "{}"))
             if not contents:
                 return Response(status=HTTPStatus.BAD_REQUEST)
-            self._create_content(contents)
+            self.directories["id"] = contents.get("rootFolderId", "")
+            self._create_content(contents.get("treeFolders", {}).get("children", []))
         except Exception as e:
             log.exception(e)
             return Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
         finally:
             self.clean_uploaded_files()
         return Response(
-            json_body=self.directories,
+            json_body=self.get_formatted_content(),
             status=HTTPStatus.OK,
         )
 
@@ -386,7 +419,7 @@ class FilesManagerXBlock(XBlock):
         if not contents:
             raise Exception("Contents not found in the request")
         for content in contents:
-            path = content.get("path")
+            path = content.get("path").rsplit("/", 1)[0]
             target_directory = self.get_target_directory(path)
             if target_directory is None:
                 raise Exception("Target directory not found")
@@ -450,20 +483,21 @@ class FilesManagerXBlock(XBlock):
             from cms.djangoapps.contentstore.asset_storage_handler import \
                 update_course_run_asset  # pylint: disable=import-outside-toplevel
 
+        if file["id"] in self.content_ids:
+            return
+
         file_object = self.temporary_uploaded_files.pop(file.get("name"), None)
         if not file_object:
             raise Exception("File not found in the temporary uploaded files")
 
-        file_path = file_object.filename
-        if target_path := file.get("path"):
-            file_path = f"{target_path}/{file_path}"
-
-        file_path, name = self.generate_content_path(file_path, file_object.filename)
+        file_path, name = self.generate_content_path(file.get("path"), file_object.filename)
         file_object.file._set_name(name)
 
         content = update_course_run_asset(self.course_id, file_object.file)
         target_directory.append(
             {
+                "id": file["id"],
+                "parentId": file.get("parentId", ""),
                 "name": name,
                 "type": "file",
                 "path": file_path,
@@ -471,6 +505,7 @@ class FilesManagerXBlock(XBlock):
             }
         )
         self.content_paths.append(file_path)
+        self.content_ids.append(file["id"])
 
     def create_directory(self, directory, target_directory):
         """Create a directory.
@@ -486,25 +521,23 @@ class FilesManagerXBlock(XBlock):
             directory: the directory to be created.
             target_directory: the target directory where the new directory will be created.
         """
-        directory_path = directory["name"]
-
-        if directory.get("path"):
-            directory_path = f"{directory['path']}/{directory['name']}"
-        directory_path, name = self.generate_content_path(directory_path, directory["name"])
-
-        target_directory.append(
-            {
-                "name": name,
-                "type": "directory",
-                "path": directory_path,
-                "metadata": {},
-                "children": [],
-            }
-        )
-        self.content_paths.append(directory_path)
+        if directory["id"] not in self.content_ids:
+            directory_path, name = self.generate_content_path(directory["path"], directory["name"])
+            target_directory.append(
+                {
+                    "id": directory["id"],
+                    "parentId": directory.get("parentId", ""),
+                    "name": name,
+                    "type": "directory",
+                    "path": directory_path,
+                    "metadata": {},
+                    "children": [],
+                }
+            )
+            self.content_paths.append(directory_path)
+            self.content_ids.append(directory["id"])
 
         for child in directory.get("children", []):
-            child["path"] = directory_path
             if child.get("type") == "directory":
                 self.create_directory(child, target_directory[-1]["children"])
             else:
@@ -585,26 +618,20 @@ class FilesManagerXBlock(XBlock):
 
         Returns: None.
         """
-        self.initialize_unpublished_directory()
         self.prefill_directories()
         return {
             "status": "success",
             "content": self.directories,
         }
 
-    def initialize_unpublished_directory(self, remove_all=False):
-        """Initialize the unpublished directory.
+    def get_formatted_content(self):
+        """Get the formatted content of the directories.
 
-        Returns: None.
+        Returns: the formatted content of the directories.
         """
-        if remove_all:
-            self.directories = [{}]
-        self.directories[0] = {
-            "name": "unpublished",
-            "type": "directory",
-            "path": "unpublished",
-            "metadata": {},
-            "children": [],
+        return {
+            "rootFolderId": self.directories["id"],
+            "treeFolders": self.directories,
         }
 
     def prefill_directories(self):
@@ -615,10 +642,10 @@ class FilesManagerXBlock(XBlock):
 
         Returns: None.
         """
-        unpublished_directory = self.directories[0]
+        unpublished_directory = self.get_content_by_path("Root/Unpublished")[0]
         all_course_assets = self.get_all_serialized_assets()
         for course_asset in all_course_assets:
-            content, _, _ = self.get_content_by_name(course_asset["display_name"], self.directories)
+            content, _, _ = self.get_content_by_name(course_asset["display_name"], self.directories["children"])
             if not content:
                 unpublished_directory["children"].append(
                     {
@@ -668,7 +695,7 @@ class FilesManagerXBlock(XBlock):
 
         Returns: the target directory if found, the root directory otherwise.
         """
-        target_directory = self.directories
+        target_directory = self.directories["children"]
         if path:
             target_directory, _, _ = self.get_content_by_path(path)
             if not target_directory:
@@ -748,8 +775,10 @@ class FilesManagerXBlock(XBlock):
 
         Returns: the content, the index of the content in the parent directory and the parent directory.
         """
+        if path == "Root":
+            return self.directories, None, None
         path_tree = path.split("/")
-        parent_directory = self.directories
+        parent_directory = self.directories["children"]
         for directory in path_tree:
             for index, content in enumerate(parent_directory):
                 if content["path"] == path:
@@ -785,15 +814,18 @@ class FilesManagerXBlock(XBlock):
             if asset_key := content.get("metadata", {}).get("asset_key"):
                 self.delete_asset(asset_key)
                 self.content_paths.remove(content["path"])
+                self.content_ids.remove(content["id"])
                 return
         for child in content.get("children", []):
             if asset_key := child.get("metadata", {}).get("asset_key"):
                 self.delete_asset(asset_key)
                 self.content_paths.remove(content["path"])
+                self.content_ids.remove(content["id"])
                 continue
             if child.get("type") == "directory":
                 self.delete_content_from_assets(child)
                 self.content_paths.remove(content["path"])
+                self.content_ids.remove(content["id"])
 
     def delete_asset(self, asset_key):
         """Delete an asset from the course assets.

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -1,4 +1,5 @@
 """Definition for the Files Manager XBlock."""
+import json
 import logging
 import os
 import pkg_resources
@@ -7,7 +8,7 @@ from django.conf import settings
 from django.utils import translation
 from webob.response import Response
 from xblock.core import XBlock
-from xblock.fields import List, Scope
+from xblock.fields import Dict, List, Scope
 from xblock.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 
@@ -114,6 +115,12 @@ class FilesManagerXBlock(XBlock):
         default=[],
         scope=Scope.settings,
         help="List of content paths to be displayed in the Files Manager."
+    )
+
+    temporary_uploaded_files = Dict(
+        default={},
+        scope=Scope.settings,
+        help="List of temporary uploaded files."
     )
 
     @property
@@ -327,43 +334,74 @@ class FilesManagerXBlock(XBlock):
             "contents": contents,
         }
 
-    @XBlock.json_handler
-    def add_directories(self, data, suffix=''):
-        """Add a directory to a target directory.
-
-        The new directory will:
-        - Be added to the target directory, if found. Otherwise, an error will be returned.
-        - Be added to the root directory if no target directory is specified.
-        - Have a path composed by the target directory path and the directory name, this path
-        will be unique.
-        - Have an empty list of children.
+    @XBlock.handler
+    def create_content(self, request, suffix=''):
+        """Associate content to the Xblock state and course assets when necessary.
 
         Arguments:
-            name: the name and path of the directory to be added.
-            path: the path of the target directory where the new directory will be added.
+            request: the request object containing the content to be added. The content can be
+            directories or a files.
+            Each request must contain the following parameters:
+            - contents: the content to be added with the following format:
+            [
+                {
+                    "name": "Folder 1",
+                    "type": "directory",
+                    "path": ..., // Empty if the directory will be added to the root directory
+                                 // or the path of the target directory where the new directory
+                                // will be added.
+                    "children": [
+                        {
+                            "name": "File 1",
+                            "type": "file",
+                            "path": "Folder 1/File 1",
+                        }
+                    ]
+                },
+            ]
+            - file(s): file(s) to be uploaded, in case the content to be added contains files.
         """
-        directories = data.get("directories")
-        if not directories:
-            return {
-                "status": "error",
-                "message": "Directories not found in the request",
-            }
-        for directory in directories:
-            path = directory.get("path")
+        try:
+            self.temporary_save_upload_files(request.params.items())
+            contents = json.loads(request.params.get("contents", "{}"))
+            if not contents:
+                return Response(status=HTTPStatus.BAD_REQUEST)
+            self._create_content(contents)
+        except Exception as e:
+            log.exception(e)
+            return Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+        finally:
+            self.clean_uploaded_files()
+        return Response(
+            json_body=self.directories,
+            status=HTTPStatus.OK,
+        )
+
+    def _create_content(self, contents):
+        """Add new content to a target directory or to the root directory.
+
+        Arguments:
+            contents: the content to be added.
+        """
+        if not contents:
+            raise Exception("Contents not found in the request")
+        for content in contents:
+            path = content.get("path")
             target_directory = self.get_target_directory(path)
             if target_directory is None:
-                return {
-                    "status": "error",
-                    "message": "Target directory not found",
-                }
-            self.create_directory(directory, target_directory)
+                raise Exception("Target directory not found")
+            if content.get("type") == "directory":
+                self.create_directory(content, target_directory)
+            elif content.get("type") == "file":
+                self.upload_file_to_directory(content, target_directory)
+            else:
+                raise Exception("Content type not found")
         return {
             "status": "success",
             "content": target_directory,
         }
 
-    @XBlock.handler
-    def upload_files(self, request, suffix=''):  # pylint: disable=unused-argument
+    def temporary_save_upload_files(self, uploaded_files):  # pylint: disable=unused-argument
         """Handler for file upload to the course assets.
 
         Arguments:
@@ -372,30 +410,17 @@ class FilesManagerXBlock(XBlock):
 
         Returns: the content of the target directory.
         """
-        target_path = request.params.get("path")
-        target_directory = self.get_target_directory(target_path)
-        if target_directory is None:
-            return Response(
-                status=HTTPStatus.NOT_FOUND,
-                json_body={
-                    "status": "error",
-                    "message": "Target directory not found",
-                }
-            )
-
-        for content_type, file in request.params.items():
+        for content_type, file in uploaded_files:
             if not content_type.startswith("file"):
                 continue
-            try:
-                self.upload_file_to_directory(file, target_directory, target_path)
-            except Exception as e:  # pylint: disable=broad-except
-                log.exception(e)
-                return Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            self.temporary_uploaded_files[file.file.name] = file
 
-        return Response(
-            status=HTTPStatus.OK,
-            json_body=target_directory,
-        )
+    def clean_uploaded_files(self):
+        """Clean the temporary uploaded files.
+
+        Returns: None.
+        """
+        self.temporary_uploaded_files = {}
 
     def generate_content_path(self, base_path, name=None):
         """Generate a new file name if the file name already exists.
@@ -409,7 +434,7 @@ class FilesManagerXBlock(XBlock):
             name = f"{name} ({len(self.content_paths)})"
         return base_path, name
 
-    def upload_file_to_directory(self, file, target_directory, target_path=None):
+    def upload_file_to_directory(self, file, target_directory):
         """Upload a file to a directory.
 
         Arguments:
@@ -425,13 +450,18 @@ class FilesManagerXBlock(XBlock):
             from cms.djangoapps.contentstore.asset_storage_handler import \
                 update_course_run_asset  # pylint: disable=import-outside-toplevel
 
-        file_path = file.filename
-        if target_path:
-            file_path = f"{target_path}/{file_path}"
-        file_path, name = self.generate_content_path(file_path, file.filename)
-        file.file._set_name(name)
+        file_object = self.temporary_uploaded_files.pop(file.get("name"), None)
+        if not file_object:
+            raise Exception("File not found in the temporary uploaded files")
 
-        content = update_course_run_asset(self.course_id, file.file)
+        file_path = file_object.filename
+        if target_path := file.get("path"):
+            file_path = f"{target_path}/{file_path}"
+
+        file_path, name = self.generate_content_path(file_path, file_object.filename)
+        file_object.file._set_name(name)
+
+        content = update_course_run_asset(self.course_id, file_object.file)
         target_directory.append(
             {
                 "name": name,
@@ -444,6 +474,13 @@ class FilesManagerXBlock(XBlock):
 
     def create_directory(self, directory, target_directory):
         """Create a directory.
+
+         The new directory will:
+        - Be added to the target directory, if found. Otherwise, an error will be returned.
+        - Be added to the root directory if no target directory is specified.
+        - Have a path composed by the target directory path and the directory name, this path
+        will be unique.
+        - Have an empty list of children unless the directory from the request contains children.
 
         Arguments:
             directory: the directory to be created.
@@ -471,7 +508,7 @@ class FilesManagerXBlock(XBlock):
             if child.get("type") == "directory":
                 self.create_directory(child, target_directory[-1]["children"])
             else:
-                self.upload_file_to_directory(child, target_directory[-1]["children"], directory_path)
+                self.upload_file_to_directory(child, target_directory[-1]["children"])
 
     @XBlock.json_handler
     def reorganize_content(self, data, suffix=''):


### PR DESCRIPTION
## Description
This PR changes the `directories` data structure and handlers to accommodate chonky definitions better. These are the changes:

- Now the Xblock definition has a sense of a `root` directory (father of all directories), which is included into the path of all directories/files
- Our UI now uses a single handler to `create_content`, content being files or even directories
- To create content, the handler accepts a FormData with `content` being the directory definition to create and `files` in case files were uploaded.
- Now, when returning the directories, each handler returns a data structure needed by chonky:
```
        {
            "rootFolderId": self.directories["id"],
            "treeFolders": self.directories,
        }
```
## How to test
- Move to this branch with the latest changes on the base branch.
- Add the Xblock into your course
- Go to Course > Select unit > Edit component 
- Add or remove directories/files
- Save your content
- It should appear in the Student view