### PR TITLE
refactor!: use unpublished directory to store uncategorized files

### DIFF
--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -101,7 +101,7 @@ class FilesManagerXBlock(XBlock):
     directories = Dict(
         default=
         {
-            "id": None,
+            "id": "root",
             "name": "Root",
             "type": "directory",
             "path": "Root",
@@ -301,7 +301,8 @@ class FilesManagerXBlock(XBlock):
             }
         ]
         """
-        if self.current_user_is_student:
+        # When outside the component edit view where there's anonymous user ID, remove unpublished directory
+        if self.get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID):
             dirs_for_student = deepcopy(self.directories)
             for directory in dirs_for_student["children"]:
                 if directory["id"] == "unpublished":
@@ -311,9 +312,8 @@ class FilesManagerXBlock(XBlock):
                 "status": "success",
                 "contents": dirs_for_student,
             }
-        # When in the component edit view where there's no anonymous user ID, prefill directories with course assets
-        if not self.get_current_user().opt_attrs.get(ATTR_KEY_ANONYMOUS_USER_ID):
-            self.fill_unpublished()
+
+        self.fill_unpublished()
         return {
             "status": "success",
             "contents": self.directories,
@@ -451,7 +451,7 @@ class FilesManagerXBlock(XBlock):
         Returns: None.
         """
         self.directories = {
-            "id": None,
+            "id": "root",
             "name": "Root",
             "type": "directory",
             "path": "Root",
@@ -639,7 +639,7 @@ class FilesManagerXBlock(XBlock):
             if not content:
                 unpublished_directory["children"].append(
                     {
-                        "id": uuid.uuid4().hex,
+                        "id": course_asset["id"],
                         "parentId": unpublished_directory["id"],
                         "name": course_asset["display_name"],
                         "type": "file",

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -427,7 +427,7 @@ class FilesManagerXBlock(XBlock):
             self.temporary_save_upload_files(request.params.items())
             contents = json.loads(request.params.get("contents", "[]"))
             self.directories["id"] = contents.get("rootFolderId", "")
-            self._create_content(contents.get("treeFolders", {}).get("children", []))
+            self._sync_content(contents.get("treeFolders", {}).get("children", []))
         except Exception as e:
             log.exception(e)
             return Response(
@@ -463,7 +463,7 @@ class FilesManagerXBlock(XBlock):
             "Root",
         ]
 
-    def _create_content(self, contents):
+    def _sync_content(self, contents):
         """Add new content to a target directory or to the root directory.
 
         Arguments:
@@ -481,6 +481,8 @@ class FilesManagerXBlock(XBlock):
                 self.upload_file_to_directory(content, target_directory)
             else:
                 raise Exception("Content type not found")
+        if not self.get_content_by_path("Root/Unpublished")[0]:
+            raise Exception("Unpublished directory cannot be removed from the root directory")
         return {
             "status": "success",
             "contents": target_directory,

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -149,14 +149,6 @@ class FilesManagerXBlock(XBlock):
         """
         return str(self.scope_ids.usage_id.block_id)
 
-    @property
-    def current_user_is_student(self):
-        """
-        Check if the user is a student.
-        """
-        current_user = self.runtime.service(self, "user").get_current_user()
-        return current_user.opt_attrs.get("edx-platform.user_role") == "student"
-
     def get_current_user(self):
         """
         Get the current user.

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -110,7 +110,7 @@ class FilesManagerXBlock(XBlock):
             "children": [
                 {
                     "id": "unpublished",
-                    "parentId": "",
+                    "parentId": "root",
                     "name": "Unpublished",
                     "type": "directory",
                     "path": "Root/Unpublished",
@@ -422,21 +422,17 @@ class FilesManagerXBlock(XBlock):
 
             - file(s): file(s) to be uploaded, in case the content to be added contains files.
         """
-        try:
-            self.initialize_directories()
-            self.temporary_save_upload_files(request.params.items())
-            contents = json.loads(request.params.get("contents", "[]"))
-            self.directories["id"] = contents.get("rootFolderId", "")
-            self._sync_content(contents.get("treeFolders", {}).get("children", []))
-        except Exception as e:
-            log.exception(e)
-            return Response(
-                str(e),
-                status=HTTPStatus.INTERNAL_SERVER_ERROR,
-            )
-        finally:
-            self.clean_uploaded_files()
-            self.fill_unpublished()
+        self.initialize_directories()
+        self.temporary_save_upload_files(request.params.items())
+
+        contents = json.loads(request.params.get("contents", "[]"))
+        self.directories["id"] = contents.get("rootFolderId", "")
+
+        self._sync_content(contents.get("treeFolders", {}).get("children", []))
+
+        self.clean_uploaded_files()
+        self.fill_unpublished()
+
         return Response(
             json_body=self.get_formatted_content(),
             status=HTTPStatus.OK,


### PR DESCRIPTION
### Description
This PR uses the `unpublished` directory for:
- Right after creating the Xblock, the assets in the course(Content > Files) are stored in it for the instructor to categorize
- When editing the xblock, the assets in Content > Files are loaded into `unpublished` folder if they haven't been categorized inside a folder by the instructor

### How to test
- Create a filesmanager component in your course
- Right after creation, the Unpublished directory should be empty if there are no assets in your course
- If you already uploaded assets into your course, they should appear in the unpublished directory
- Now, log in as a student. You shouldn't be able to see the unpublished directory
- Every time you upload an asset in the Content > Files, it should appear in the directory