### PR TITLE
 refactor!: sync directory data structure to accommodate chonky definitions

### DIFF
--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -583,7 +583,8 @@ class FilesManagerXBlock(XBlock):
                 "message": "Path not found",
             }
         for content in contents:
-            self.delete_asset(content)
+            if content:
+                self.delete_asset(content)
         return {
             "status": "success",
         }

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -116,7 +116,7 @@ class FilesManagerXBlock(XBlock):
             ],
         },
         scope=Scope.settings,
-        help="List of directories to be displayed in the Files Manager."
+        help="Directory tree to be displayed in the Files Manager."
     )
 
     content_paths = List(

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -349,27 +349,47 @@ class FilesManagerXBlock(XBlock):
     def sync_content(self, request, suffix=''):
         """Associate content to the Xblock state and course assets when necessary.
 
+        This handler does the following:
+        - Initialize the directories list with the content of the course assets.
+        - Temporary save the uploaded files so we can reference them later.
+        - Add new content to a target directory or to the root directory.
+        - Clean the temporary uploaded files.
+        - Return the content of the parent directory.
+
         Arguments:
             request: the request object containing the content to be added. The content can be
             directories or a files.
             Each request must contain the following parameters:
             - contents: the content to be added with the following format:
-            [
-                {
-                    "name": "Folder 1",
+            {
+                "rootFolderId": ...,
+                "treeFolders": {
+                    "id": "<rootFolderId>",
+                    "name": "Root",
                     "type": "directory",
-                    "path": ..., // Empty if the directory will be added to the root directory
-                                 // or the path of the target directory where the new directory
-                                // will be added.
+                    "path": "Root",
+                    "parentId": "",
+                    "metadata": {},
                     "children": [
                         {
-                            "name": "File 1",
-                            "type": "file",
-                            "path": "Folder 1/File 1",
-                        }
+                            "id": <folderId>,
+                            "name": "Folder 1",
+                            "type": "directory",
+                            "path": "Root/Folder 1",
+                            "parentId": "<rootFolderId>",
+                            "children": [
+                                {
+                                    "id": <fileId>,
+                                    "parentId": "<folderId>",
+                                    "name": "File 1",
+                                    "type": "file",
+                                    "path": "Root/Folder 1/File 1",
+                                }
+                            ]
+                        },
                     ]
-                },
-            ]
+            }
+
             - file(s): file(s) to be uploaded, in case the content to be added contains files.
         """
         try:

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -399,7 +399,10 @@ class FilesManagerXBlock(XBlock):
             self._create_content(contents.get("treeFolders", {}).get("children", []))
         except Exception as e:
             log.exception(e)
-            return Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return Response(
+                str(e),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+            )
         finally:
             self.clean_uploaded_files()
             # self.prefill_directories()

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -99,7 +99,7 @@ class FilesManagerXBlock(XBlock):
     directories = Dict(
         default=
         {
-            "id": None,
+            "id": uuid.uuid4().hex,
             "name": "Root",
             "type": "directory",
             "path": "Root",
@@ -131,11 +131,6 @@ class FilesManagerXBlock(XBlock):
         scope=Scope.settings,
         help="List of temporary uploaded files."
     )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        parent_id = uuid.uuid4().hex
-        self.directories["id"] = parent_id
 
     @property
     def block_id(self):

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -287,7 +287,7 @@ class FilesManagerXBlock(XBlock):
         # self.prefill_directories()
         return {
             "status": "success",
-            "content": self.directories,
+            "contents": self.directories,
         }
 
     @XBlock.json_handler
@@ -321,7 +321,7 @@ class FilesManagerXBlock(XBlock):
         self.content_paths = []
         return {
             "status": "success",
-            "content": self.directories,
+            "contents": self.directories,
         }
 
     @XBlock.json_handler
@@ -342,7 +342,7 @@ class FilesManagerXBlock(XBlock):
         content, _, _ = self.get_content_by_path(path)
         return {
             "status": "success",
-            "content": content,
+            "contents": content,
         }
 
     @XBlock.handler
@@ -459,7 +459,7 @@ class FilesManagerXBlock(XBlock):
                 raise Exception("Content type not found")
         return {
             "status": "success",
-            "content": target_directory,
+            "contents": target_directory,
         }
 
     def temporary_save_upload_files(self, uploaded_files):  # pylint: disable=unused-argument

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -604,16 +604,16 @@ class FilesManagerXBlock(XBlock):
 
         Returns: None.
         """
-        unpublished_directory = self.get_content_by_path("Root/Unpublished")[0]
+        unpublished_directory = self.directories[0]
         all_course_assets = self.get_all_serialized_assets()
         for course_asset in all_course_assets:
-            content, _, _ = self.get_content_by_name(course_asset["display_name"], self.directories["children"])
+            content, _, _ = self.get_content_by_name(course_asset["display_name"], self.directories)
             if not content:
                 unpublished_directory["children"].append(
                     {
                         "name": course_asset["display_name"],
                         "type": "file",
-                        "path": f"Unpublished/{course_asset['display_name']}",
+                        "path": f"unpublished/{course_asset['display_name']}",
                         "metadata": course_asset,
                     }
                 )

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -558,17 +558,14 @@ class FilesManagerXBlock(XBlock):
 
         Returns: the content of the parent directory.
         """
-        paths = data.get("paths")
-        if not paths:
+        contents = data.get("contents")
+        if not contents:
             return {
                 "status": "error",
                 "message": "Path not found",
             }
-        for path in paths:
-            content, index, parent_directory = self.get_content_by_path(path)
-            if content:
-                del parent_directory[index]
-                self.delete_content_from_assets(content)
+        for content in contents:
+            self.delete_asset(content)
         return {
             "status": "success",
         }
@@ -737,28 +734,6 @@ class FilesManagerXBlock(XBlock):
                     parent_directory = content["children"]
                     break
         return None, None, None
-
-    def delete_content_from_assets(self, content):
-        """Delete a content from the course assets.
-
-        Arguments:
-            content: the content to be deleted.
-
-        Returns: None.
-        """
-        if content.get("type") == "file":
-            if asset_key := content.get("metadata", {}).get("asset_key"):
-                self.delete_asset(asset_key)
-                self.content_paths.remove(content["path"])
-                return
-        for child in content.get("children", []):
-            if asset_key := child.get("metadata", {}).get("asset_key"):
-                self.delete_asset(asset_key)
-                self.content_paths.remove(content["path"])
-                continue
-            if child.get("type") == "directory":
-                self.delete_content_from_assets(child)
-                self.content_paths.remove(content["path"])
 
     def delete_asset(self, asset_key):
         """Delete an asset from the course assets.

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -512,13 +512,15 @@ class FilesManagerXBlock(XBlock):
                 update_course_run_asset  # pylint: disable=import-outside-toplevel
 
         file_object = self.temporary_uploaded_files.pop(file.get("name"), None)
-        if not file_object:
-            raise Exception("File not found in the temporary uploaded files")
+        file_path, name = file.get("path"), file.get("name")
+        metadata = file.get("metadata", {})
 
-        file_path, name = self.generate_content_path(file.get("path"), file_object.filename)
-        file_object.file._set_name(name)
+        if file_object:
+            file_path, name = self.generate_content_path(file_path, file_object.filename)
+            file_object.file._set_name(name)
+            content = update_course_run_asset(self.course_id, file_object.file)
+            metadata = self.get_asset_json_from_content(content)
 
-        content = update_course_run_asset(self.course_id, file_object.file)
         target_directory.append(
             {
                 "id": file["id"],
@@ -526,7 +528,7 @@ class FilesManagerXBlock(XBlock):
                 "name": name,
                 "type": "file",
                 "path": file_path,
-                "metadata": self.get_asset_json_from_content(content),
+                "metadata": metadata,
             }
         )
         self.content_paths.append(file_path)

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -333,19 +333,16 @@ class FilesManagerXBlock(XBlock):
 
         Returns: the content of the directory if found, an empty sequence otherwise.
         """
-        paths = data.get("paths")
-        if not paths:
+        path = data.get("path")
+        if not path:
             return {
                 "status": "error",
                 "message": "Path not found",
             }
-        contents = []
-        for path in paths:
-            content, _, _ = self.get_content_by_path(path)
-            contents.append(content)
+        content, _, _ = self.get_content_by_path(path)
         return {
             "status": "success",
-            "contents": contents,
+            "content": content,
         }
 
     @XBlock.handler

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -2,8 +2,10 @@
 import json
 import logging
 import os
+from http import HTTPStatus
+from urllib.parse import urljoin
+
 import pkg_resources
-import uuid
 from django.conf import settings
 from django.utils import translation
 from webob.response import Response
@@ -11,9 +13,6 @@ from xblock.core import XBlock
 from xblock.fields import Dict, List, Scope
 from xblock.fragment import Fragment
 from xblockutils.resources import ResourceLoader
-
-from http import HTTPStatus
-from urllib.parse import urljoin
 
 try:
     from cms.djangoapps.contentstore.exceptions import AssetNotFoundException
@@ -99,7 +98,7 @@ class FilesManagerXBlock(XBlock):
     directories = Dict(
         default=
         {
-            "id": uuid.uuid4().hex,
+            "id": None,
             "name": "Root",
             "type": "directory",
             "path": "Root",
@@ -520,7 +519,7 @@ class FilesManagerXBlock(XBlock):
 
         target_directory.append(
             {
-                "id": file.get("id") or uuid.uuid4().hex,
+                "id": file.get("id"),
                 "parentId": file.get("parentId", ""),
                 "name": name,
                 "type": "file",
@@ -547,7 +546,7 @@ class FilesManagerXBlock(XBlock):
         directory_path, name = self.generate_content_path(directory["path"], directory["name"])
         target_directory.append(
             {
-                "id": directory.get("id") or uuid.uuid4().hex,
+                "id": directory.get("id"),
                 "parentId": directory.get("parentId", ""),
                 "name": name,
                 "type": "directory",

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -442,8 +442,7 @@ class FilesManagerXBlock(XBlock):
         Arguments:
             contents: the content to be added.
         """
-        if not contents:
-            raise Exception("Contents not found in the request")
+        target_directory = self.directories
         for content in contents:
             path = content.get("path").rsplit("/", 1)[0]
             target_directory = self.get_target_directory(path)

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -99,7 +99,7 @@ class FilesManagerXBlock(XBlock):
     directories = Dict(
         default=
         {
-            "id": None,
+            "id": uuid.uuid4().hex,
             "name": "Root",
             "type": "directory",
             "path": "Root",

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -284,7 +284,7 @@ class FilesManagerXBlock(XBlock):
             }
         ]
         """
-        self.prefill_directories()
+        # self.prefill_directories()
         return {
             "status": "success",
             "content": self.directories,
@@ -317,7 +317,7 @@ class FilesManagerXBlock(XBlock):
                 # }
             ],
         }
-        self.prefill_directories()
+        # self.prefill_directories()
         self.content_paths = []
         return {
             "status": "success",
@@ -388,7 +388,7 @@ class FilesManagerXBlock(XBlock):
             return Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
         finally:
             self.clean_uploaded_files()
-            self.prefill_directories()
+            # self.prefill_directories()
         return Response(
             json_body=self.get_formatted_content(),
             status=HTTPStatus.OK,

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -3,12 +3,12 @@ import json
 import logging
 import os
 import pkg_resources
-import re
+import uuid
 from django.conf import settings
 from django.utils import translation
 from webob.response import Response
 from xblock.core import XBlock
-from xblock.fields import Dict, List, Scope, String
+from xblock.fields import Dict, List, Scope
 from xblock.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 
@@ -395,9 +395,7 @@ class FilesManagerXBlock(XBlock):
         try:
             self.initialize_directories()
             self.temporary_save_upload_files(request.params.items())
-            contents = json.loads(request.params.get("contents", "{}"))
-            if not contents:
-                return Response(status=HTTPStatus.BAD_REQUEST)
+            contents = json.loads(request.params.get("contents", "[]"))
             self.directories["id"] = contents.get("rootFolderId", "")
             self._create_content(contents.get("treeFolders", {}).get("children", []))
         except Exception as e:
@@ -462,7 +460,7 @@ class FilesManagerXBlock(XBlock):
             "contents": target_directory,
         }
 
-    def temporary_save_upload_files(self, uploaded_files):  # pylint: disable=unused-argument
+    def temporary_save_upload_files(self, uploaded_files):
         """Handler for file upload to the course assets.
 
         Arguments:
@@ -523,7 +521,7 @@ class FilesManagerXBlock(XBlock):
 
         target_directory.append(
             {
-                "id": file["id"],
+                "id": file.get("id") or uuid.uuid4().hex,
                 "parentId": file.get("parentId", ""),
                 "name": name,
                 "type": "file",
@@ -550,7 +548,7 @@ class FilesManagerXBlock(XBlock):
         directory_path, name = self.generate_content_path(directory["path"], directory["name"])
         target_directory.append(
             {
-                "id": directory["id"],
+                "id": directory.get("id") or uuid.uuid4().hex,
                 "parentId": directory.get("parentId", ""),
                 "name": name,
                 "type": "directory",

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -589,7 +589,6 @@ class FilesManagerXBlock(XBlock):
         Returns: None.
         """
         unpublished_directory = self.get_content_by_path("Root/Unpublished")[0]
-        unpublished_directory["children"] = []
         all_course_assets = self.get_all_serialized_assets()
         for course_asset in all_course_assets:
             content, _, _ = self.get_content_by_name(course_asset["display_name"], self.directories["children"])

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -110,10 +110,10 @@ class FilesManagerXBlock(XBlock):
         help="List of directories to be displayed in the Files Manager."
     )
 
-    content_ids = List(
+    content_paths = List(
         default=[],
         scope=Scope.settings,
-        help="List of content IDs to be displayed in the Files Manager."
+        help="List of content paths to be displayed in the Files Manager."
     )
 
     @property
@@ -282,8 +282,9 @@ class FilesManagerXBlock(XBlock):
 
         Returns: an empty list of directories.
         """
-        self.initialize_unpublished_directory()
+        self.initialize_unpublished_directory(remove_all=True)
         self.prefill_directories()
+        self.content_paths = []
         return {
             "status": "success",
             "content": self.directories,
@@ -298,16 +299,19 @@ class FilesManagerXBlock(XBlock):
 
         Returns: the content of the directory if found, an empty sequence otherwise.
         """
-        path = data.get("path")
-        if not path:
+        paths = data.get("paths")
+        if not paths:
             return {
                 "status": "error",
                 "message": "Path not found",
             }
-        content, _, _ = self.get_content_by_path(path)
+        contents = []
+        for path in paths:
+            content, _, _ = self.get_content_by_path(path)
+            contents.append(content)
         return {
             "status": "success",
-            "content": content,
+            "contents": contents,
         }
 
     @XBlock.json_handler
@@ -317,8 +321,8 @@ class FilesManagerXBlock(XBlock):
         The new directory will:
         - Be added to the target directory, if found. Otherwise, an error will be returned.
         - Be added to the root directory if no target directory is specified.
-        - Have a unique incremental ID.
-        - Have a path composed by the target directory path and the directory name.
+        - Have a path composed by the target directory path and the directory name, this path
+        will be unique.
         - Have an empty list of children.
 
         Arguments:
@@ -332,7 +336,6 @@ class FilesManagerXBlock(XBlock):
                 "message": "Directories not found in the request",
             }
         for directory in directories:
-            directory_name = directory.get("name")
             path = directory.get("path")
             target_directory = self.get_target_directory(path)
             if target_directory is None:
@@ -340,22 +343,7 @@ class FilesManagerXBlock(XBlock):
                     "status": "error",
                     "message": "Target directory not found",
                 }
-            directory_path = f"{path}/{directory_name}" if path else directory_name
-            if directory_path in self.content_ids:
-                return {
-                    "status": "error",
-                    "message": f"Directory {directory_name} already exists",
-                }
-            self.content_ids.append(directory_path)
-            target_directory.append(
-                {
-                    "name": directory_name,
-                    "type": "directory",
-                    "path": directory_path,
-                    "metadata": {},  # Empty for now but could be used to store the directory data needed by Chonky.
-                    "children": [],
-                }
-            )
+            self.create_directory(directory, target_directory)
         return {
             "status": "success",
             "content": target_directory,
@@ -371,13 +359,6 @@ class FilesManagerXBlock(XBlock):
 
         Returns: the content of the target directory.
         """
-        # Temporary fix for supporting both contentstore assets management versions (master / Palm)
-        try:
-            from cms.djangoapps.contentstore.views.assets import \
-                update_course_run_asset  # pylint: disable=import-outside-toplevel
-        except ImportError:
-            from cms.djangoapps.contentstore.asset_storage_handler import \
-                update_course_run_asset  # pylint: disable=import-outside-toplevel
         target_path = request.params.get("path")
         target_directory = self.get_target_directory(target_path)
         if target_directory is None:
@@ -392,26 +373,8 @@ class FilesManagerXBlock(XBlock):
         for content_type, file in request.params.items():
             if not content_type.startswith("file"):
                 continue
-            file_path = f"{target_path}/{file.filename}" if target_path else file.filename
-            if file_path in self.content_ids:
-                return Response(
-                    status=HTTPStatus.CONFLICT,
-                    json_body={
-                        "status": "error",
-                        "message": "File already exists",
-                    }
-                )
             try:
-                content = update_course_run_asset(self.course_id, file.file)
-                self.content_ids.append(file_path)
-                target_directory.append(
-                    {
-                        "name": file.filename,
-                        "type": "file",
-                        "path": file_path,
-                        "metadata": self.get_asset_json_from_content(content),
-                    }
-                )
+                self.upload_file_to_directory(file, target_directory, target_path)
             except Exception as e:  # pylint: disable=broad-except
                 log.exception(e)
                 return Response(status=HTTPStatus.INTERNAL_SERVER_ERROR)
@@ -420,6 +383,82 @@ class FilesManagerXBlock(XBlock):
             status=HTTPStatus.OK,
             json_body=target_directory,
         )
+
+    def generate_content_path(self, base_path, name=None):
+        """Generate a new file name if the file name already exists.
+        Args:
+            base_name (str): The content name to check.
+        Returns:
+            str: The new file name.
+        """
+        if base_path in self.content_paths:
+            base_path = f"{base_path} ({len(self.content_paths)})"
+            name = f"{name} ({len(self.content_paths)})"
+        return base_path, name
+
+    def upload_file_to_directory(self, file, target_directory, target_path=None):
+        """Upload a file to a directory.
+
+        Arguments:
+            file: the file to be uploaded.
+            target_directory: the target directory where the file will be uploaded.
+
+        Returns: the content of the target directory.
+        """
+        try:
+            from cms.djangoapps.contentstore.views.assets import \
+                update_course_run_asset  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            from cms.djangoapps.contentstore.asset_storage_handler import \
+                update_course_run_asset  # pylint: disable=import-outside-toplevel
+
+        file_path = file.filename
+        if target_path:
+            file_path = f"{target_path}/{file_path}"
+        file_path, name = self.generate_content_path(file_path, file.filename)
+        file.file._set_name(name)
+
+        content = update_course_run_asset(self.course_id, file.file)
+        target_directory.append(
+            {
+                "name": name,
+                "type": "file",
+                "path": file_path,
+                "metadata": self.get_asset_json_from_content(content),
+            }
+        )
+        self.content_paths.append(file_path)
+
+    def create_directory(self, directory, target_directory):
+        """Create a directory.
+
+        Arguments:
+            directory: the directory to be created.
+            target_directory: the target directory where the new directory will be created.
+        """
+        directory_path = directory["name"]
+
+        if directory.get("path"):
+            directory_path = f"{directory['path']}/{directory['name']}"
+        directory_path, name = self.generate_content_path(directory_path, directory["name"])
+
+        target_directory.append(
+            {
+                "name": name,
+                "type": "directory",
+                "path": directory_path,
+                "metadata": {},
+                "children": [],
+            }
+        )
+        self.content_paths.append(directory_path)
+
+        for child in directory.get("children", []):
+            child["path"] = directory_path
+            if child.get("type") == "directory":
+                self.create_directory(child, target_directory[-1]["children"])
+            else:
+                self.upload_file_to_directory(child, target_directory[-1]["children"], directory_path)
 
     @XBlock.json_handler
     def reorganize_content(self, data, suffix=''):
@@ -496,26 +535,27 @@ class FilesManagerXBlock(XBlock):
 
         Returns: None.
         """
+        self.initialize_unpublished_directory()
         self.prefill_directories()
         return {
             "status": "success",
             "content": self.directories,
         }
 
-    def initialize_unpublished_directory(self):
+    def initialize_unpublished_directory(self, remove_all=False):
         """Initialize the unpublished directory.
 
         Returns: None.
         """
-        self.directories = [
-            {
-                "name": "unpublished",
-                "type": "directory",
-                "path": "unpublished",
-                "metadata": {},
-                "children": [],
-            }
-        ]
+        if remove_all:
+            self.directories = [{}]
+        self.directories[0] = {
+            "name": "unpublished",
+            "type": "directory",
+            "path": "unpublished",
+            "metadata": {},
+            "children": [],
+        }
 
     def prefill_directories(self):
         """Prefill the directories list with the content of the course assets.
@@ -569,7 +609,6 @@ class FilesManagerXBlock(XBlock):
             start += COURSE_ASSETS_PAGE_SIZE
             current_page += 1
         return serialized_course_assets
-
 
     def get_target_directory(self, path):
         """Get the target directory for a given path.
@@ -695,13 +734,16 @@ class FilesManagerXBlock(XBlock):
         if content.get("type") == "file":
             if asset_key := content.get("metadata", {}).get("asset_key"):
                 self.delete_asset(asset_key)
+                self.content_paths.remove(content["path"])
                 return
         for child in content.get("children", []):
             if asset_key := child.get("metadata", {}).get("asset_key"):
                 self.delete_asset(asset_key)
+                self.content_paths.remove(content["path"])
                 continue
             if child.get("type") == "directory":
                 self.delete_content_from_assets(child)
+                self.content_paths.remove(content["path"])
 
     def delete_asset(self, asset_key):
         """Delete an asset from the course assets.

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -311,7 +311,7 @@ class FilesManagerXBlock(XBlock):
         }
 
     @XBlock.json_handler
-    def add_directory(self, data, suffix=''):
+    def add_directories(self, data, suffix=''):
         """Add a directory to a target directory.
 
         The new directory will:
@@ -325,30 +325,37 @@ class FilesManagerXBlock(XBlock):
             name: the name and path of the directory to be added.
             path: the path of the target directory where the new directory will be added.
         """
-        directory_name = data.get("name")
-        path = data.get("path")
-        target_directory = self.get_target_directory(path)
-        if target_directory is None:
+        directories = data.get("directories")
+        if not directories:
             return {
                 "status": "error",
-                "message": "Target directory not found",
+                "message": "Directories not found in the request",
             }
-        directory_path = f"{path}/{directory_name}" if path else directory_name
-        if directory_path in self.content_ids:
-            return {
-                "status": "error",
-                "message": "Directory already exists",
-            }
-        self.content_ids.append(directory_path)
-        target_directory.append(
-            {
-                "name": directory_name,
-                "type": "directory",
-                "path": f"{path}/{directory_name}" if path else directory_name,
-                "metadata": {},  # Empty for now but could be used to store the directory data needed by Chonky.
-                "children": [],
-            }
-        )
+        for directory in directories:
+            directory_name = directory.get("name")
+            path = directory.get("path")
+            target_directory = self.get_target_directory(path)
+            if target_directory is None:
+                return {
+                    "status": "error",
+                    "message": "Target directory not found",
+                }
+            directory_path = f"{path}/{directory_name}" if path else directory_name
+            if directory_path in self.content_ids:
+                return {
+                    "status": "error",
+                    "message": f"Directory {directory_name} already exists",
+                }
+            self.content_ids.append(directory_path)
+            target_directory.append(
+                {
+                    "name": directory_name,
+                    "type": "directory",
+                    "path": directory_path,
+                    "metadata": {},  # Empty for now but could be used to store the directory data needed by Chonky.
+                    "children": [],
+                }
+            )
         return {
             "status": "success",
             "content": target_directory,

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -99,7 +99,7 @@ class FilesManagerXBlock(XBlock):
     directories = Dict(
         default=
         {
-            "id": uuid.uuid4().hex,
+            "id": None,
             "name": "Root",
             "type": "directory",
             "path": "Root",
@@ -131,6 +131,11 @@ class FilesManagerXBlock(XBlock):
         scope=Scope.settings,
         help="List of temporary uploaded files."
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        parent_id = uuid.uuid4().hex
+        self.directories["id"] = parent_id
 
     @property
     def block_id(self):

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -126,12 +126,6 @@ class FilesManagerXBlock(XBlock):
         help="List of content paths to be displayed in the Files Manager."
     )
 
-    content_ids = List(
-        default=[],
-        scope=Scope.settings,
-        help="List of content (from Chunky) ids to be displayed in the Files Manager."
-    )
-
     temporary_uploaded_files = Dict(
         default={},
         scope=Scope.settings,
@@ -325,7 +319,6 @@ class FilesManagerXBlock(XBlock):
         }
         self.prefill_directories()
         self.content_paths = []
-        self.content_ids = []
         return {
             "status": "success",
             "content": self.directories,
@@ -428,7 +421,6 @@ class FilesManagerXBlock(XBlock):
             ],
         }
         self.content_paths = []
-        self.content_ids = []
 
     def _create_content(self, contents):
         """Add new content to a target directory or to the root directory.
@@ -503,9 +495,6 @@ class FilesManagerXBlock(XBlock):
             from cms.djangoapps.contentstore.asset_storage_handler import \
                 update_course_run_asset  # pylint: disable=import-outside-toplevel
 
-        if file["id"] in self.content_ids:
-            return
-
         file_object = self.temporary_uploaded_files.pop(file.get("name"), None)
         if not file_object:
             raise Exception("File not found in the temporary uploaded files")
@@ -525,7 +514,6 @@ class FilesManagerXBlock(XBlock):
             }
         )
         self.content_paths.append(file_path)
-        self.content_ids.append(file["id"])
 
     def create_directory(self, directory, target_directory):
         """Create a directory.
@@ -541,21 +529,19 @@ class FilesManagerXBlock(XBlock):
             directory: the directory to be created.
             target_directory: the target directory where the new directory will be created.
         """
-        if directory["id"] not in self.content_ids:
-            directory_path, name = self.generate_content_path(directory["path"], directory["name"])
-            target_directory.append(
-                {
-                    "id": directory["id"],
-                    "parentId": directory.get("parentId", ""),
-                    "name": name,
-                    "type": "directory",
-                    "path": directory_path,
-                    "metadata": {},
-                    "children": [],
-                }
-            )
-            self.content_paths.append(directory_path)
-            self.content_ids.append(directory["id"])
+        directory_path, name = self.generate_content_path(directory["path"], directory["name"])
+        target_directory.append(
+            {
+                "id": directory["id"],
+                "parentId": directory.get("parentId", ""),
+                "name": name,
+                "type": "directory",
+                "path": directory_path,
+                "metadata": {},
+                "children": [],
+            }
+        )
+        self.content_paths.append(directory_path)
 
         for child in directory.get("children", []):
             if child.get("type") == "directory":
@@ -764,18 +750,15 @@ class FilesManagerXBlock(XBlock):
             if asset_key := content.get("metadata", {}).get("asset_key"):
                 self.delete_asset(asset_key)
                 self.content_paths.remove(content["path"])
-                self.content_ids.remove(content["id"])
                 return
         for child in content.get("children", []):
             if asset_key := child.get("metadata", {}).get("asset_key"):
                 self.delete_asset(asset_key)
                 self.content_paths.remove(content["path"])
-                self.content_ids.remove(content["id"])
                 continue
             if child.get("type") == "directory":
                 self.delete_content_from_assets(child)
                 self.content_paths.remove(content["path"])
-                self.content_ids.remove(content["id"])
 
     def delete_asset(self, asset_key):
         """Delete an asset from the course assets.

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -394,8 +394,7 @@ class FilesManagerXBlock(XBlock):
     def initialize_directories(self):
         """Initialize the directories list with the content of the course assets.
 
-        This unorganized content will be added to the unpublished directory, which is the first
-        directory in the directory list.
+        The directory data structure is initialized every time the sync_content method is called.
 
         Returns: None.
         """

--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -106,13 +106,14 @@ class FilesManagerXBlock(XBlock):
             "parentId": "",
             "metadata": {},
             "children": [
-                {
-                    "name": "Unpublished",
-                    "type": "directory",
-                    "path": "Root/Unpublished",
-                    "metadata": {},
-                    "children": [],
-                }
+                # Commented in the meantime while we figure out how to integrate this folder into Chonky
+                # {
+                #     "name": "Unpublished",
+                #     "type": "directory",
+                #     "path": "Root/Unpublished",
+                #     "metadata": {},
+                #     "children": [],
+                # }
             ],
         },
         scope=Scope.settings,
@@ -311,13 +312,14 @@ class FilesManagerXBlock(XBlock):
             "parentId": "",
             "metadata": {},
             "children": [
-                {
-                    "name": "Unpublished",
-                    "type": "directory",
-                    "path": "Root/Unpublished",
-                    "metadata": {},
-                    "children": [],
-                }
+                # Commented in the meantime while we figure out how to integrate this folder into Chonky
+                # {
+                #     "name": "Unpublished",
+                #     "type": "directory",
+                #     "path": "Root/Unpublished",
+                #     "metadata": {},
+                #     "children": [],
+                # }
             ],
         }
         self.prefill_directories()
@@ -637,7 +639,7 @@ class FilesManagerXBlock(XBlock):
                     {
                         "name": course_asset["display_name"],
                         "type": "file",
-                        "path": f"unpublished/{course_asset['display_name']}",
+                        "path": f"Unpublished/{course_asset['display_name']}",
                         "metadata": course_asset,
                     }
                 )


### PR DESCRIPTION
### Description
This PR changes how data is stored and what's stored in the xblock state. Now the `directories` data structure and handlers to accommodate chonky definitions better. These are the changes on the data structure level:

- Now the Xblock definition has a sense of a `root` directory (father of all directories), which is included in the path of all directories/files
- We keep track of paths so we can upload duplicated data
- Now, when returning the directories, each handler returns a data structure needed by chonky:
```
        {
            "rootFolderId": self.directories["id"],
            "treeFolders": self.directories,
        }
```

On how it is stored: 
- Instead of using a single object modified by adding/removing/... folders or files, the main operation is a _synchronization_, so when receiving new data from the client the old `directories` field is updated using what's init. 
- To sync content, the handler accepts a FormData with `content` being the directory definition to create and `files` in case files were uploaded.

For example, let's say this is the current directories:

```
{
    "rootFolderId": "qwerty123456",
    "treeFolders": {
        "id": "qwerty123456",
        "name": "Root",
        "type": "directory",
        "path": "Root",
        "metadata": {},
        "parentId": "",
        "children": [
            {
                "id": "folder-Home-0",
                "name": "Home",
                "type": "directory",
                "path": "Root/Home",
                "metadata": {},
                "parentId": "qwerty123456",
                "children": [
                    {
                        "id": "folder-Images-1",
                        "name": "Images",
                        "type": "directory",
                        "path": "Root/Home/Images",
                        "metadata": {},
                        "parentId": "folder-Home-0",
                    }
                ]
            }
        ]
    }
}
```
Now, when the client requests POST to `sync_content` with:

```
{
    "rootFolderId": "qwerty123456",
    "treeFolders": {
        "id": "qwerty123456",
        "name": "Root",
        "type": "directory",
        "path": "Root",
        "metadata": {},
        "parentId": "",
        "children": [
            {
                "id": "folder-Home-0",
                "name": "Home",
                "type": "directory",
                "path": "Root/Home",
                "metadata": {},
                "parentId": "qwerty123456"
            }
        ]
    }
}
```
If we refer to the xblock status for `directories` or call POST `get_directories` the last synchronization would be returned.

A couple of notes:
- The client generates the ID. I suggested we use UUIDs instead of those strings.
- That ID is only used by Chonky, the Xblock saves it.
- The variables in camel case are used just that's how the frontend receives it. I'm aware it's not a good practice in Python.
- These changes are being made to accommodate the chonky library so it works smoothly. I

### How to test

Using this postman collection: 

https://edunext.postman.co/workspace/My-Workspace~6db73e5a-6e48-4156-84e2-2138cee67ae1/collection/11825345-8bd85fab-c7d7-43f6-8bb7-4121c73f833d?action=share&creator=11825345&active-environment=11825345-d74233f0-ba6b-4b85-9166-abab2cc7c6c2

#### Postman setup
1. If you're not using the postman interceptor, then fill in the environment variables for your authentication:
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/07490ccf-e074-4c65-b320-ccb6866acff6)
To get the information you can:
- Add the Xblock to a course
- Select your course > component
- Open the network console
- Then, copy the CSRF-X token & cookies (spec) from the `get_content` header request:
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/50b422ec-628b-4bb0-acc7-d1e41bbac1b9)
- You can also save the location where the request is being made to complete the environment. In this case: `block-v1:demo+filemanager-v1+2023+type@filesmanager+block@9e3eef05e72b4e4ab71686e9abad4bf9`, that would be our `block_id`
- Your environment should look like this now:
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/19acbd34-0043-4d6c-a554-f34bf494bb9c)

#### Tests setup
- You can use the above examples for the test inputs for the `sync_content`. You can also add new images by doing the following:
![image](https://github.com/eduNEXT/xblock-filesmanager/assets/64440265/b8662656-2c83-4dd9-9702-3d8ada645a1b)

With:
- content: structure to synchronize
```
{
    "rootFolderId": "qwerty123456",
    "treeFolders": {
        "id": "qwerty123456",
        "name": "Root",
        "type": "directory",
        "path": "Root",
        "metadata": {},
        "parentId": "",
        "children": [
            {
                "id": "folder-Home-0",
                "name": "Home",
                "type": "directory",
                "path": "Root/Home",
                "metadata": {},
                "parentId": "qwerty123456",
                "children": [
                    {
                        "id": "folder-Images-1",
                        "name": "Images",
                        "type": "directory",
                        "path": "Root/Home/Images",
                        "metadata": {},
                        "parentId": "folder-Home-0",
                        "children": [
                            {
                                "id": "caracas-image-1",
                                "type": "file",
                                "path": "Root/Home/Images/caracas.png",
                                "name": "caracas.png",
                                "parentId": "folder-Home-0"
                            }
                        ]
                    }
                ]
            }
        }
```
- file: files to upload, you can add one from your working directory. But you'll have to change the previous structure.