### PR TITLE
fix: compare ID instead of whole object to avoid badly cast fields

### DIFF
--- a/filesmanager/filesmanager.py
+++ b/filesmanager/filesmanager.py
@@ -486,10 +486,10 @@ class FilesManagerXBlock(XBlock):
         - Compare the files from the course assets with the files from the directories list.
         - Remove the files that are in the directory list but not in the course assets.
         """
-        course_assets_files = self.get_all_serialized_assets()
+        course_assets_ids = [asset["id"] for asset in self.get_all_serialized_assets()]
         directories_files = self.get_all_files(self.directories["children"])
         for file in directories_files:
-            if file["metadata"] not in course_assets_files:
+            if file["metadata"]["id"] not in course_assets_ids:
                 self.delete_file_from_directory(file)
 
     def delete_file_from_directory(self, file):


### PR DESCRIPTION
### Description
This PR fixes a bug when synchronizing course assets with the xblock state. One of the metadata fields didn't match the type (I think file_size from the frontend was cast to string), so the handler moved the recently uploaded files to the unpublished directory.

### Testing instructions

1. Upload a file to the root directory
2. Save
3. Edit block, you should see the file